### PR TITLE
Add an extra check for a dialogs property

### DIFF
--- a/src/redux-reactstrap-modal.js
+++ b/src/redux-reactstrap-modal.js
@@ -19,7 +19,7 @@ const reduxReactstrapModal = (settings) => {
         };
 
         const mapStateToProps = (state) => {
-            if (state.dialogReducer.dialogs.length && state.dialogReducer.dialogs[name] !== undefined) {
+            if (state.dialogReducer.dialogs !== undefined && state.dialogReducer.dialogs[name] !== undefined) {
               const modal = state.dialogReducer.dialogs[name];
               const isOpen = modal && modal.open;
               const data = modal ? modal.data : undefined;

--- a/src/redux-reactstrap-modal.js
+++ b/src/redux-reactstrap-modal.js
@@ -19,13 +19,15 @@ const reduxReactstrapModal = (settings) => {
         };
 
         const mapStateToProps = (state) => {
-
-            let modal = state.dialogReducer.dialogs[name];
-            let isOpen = modal && modal.open;
-            let data = modal ? modal.data : undefined;
-            return {isOpen: isOpen, data: data};
+            if (state.dialogReducer.dialogs.length && state.dialogReducer.dialogs[name] !== undefined) {
+              const modal = state.dialogReducer.dialogs[name];
+              const isOpen = modal && modal.open;
+              const data = modal ? modal.data : undefined;
+              return { isOpen, data };
+            }
+            return { isOpen: false, data: {} }
         };
-
+        
         const mapDispatchToProps = (dispatch, props) => ({
             toggle: () => {
                 dispatch(toggleDialog(name))


### PR DESCRIPTION
As per issue https://github.com/anis-campos/redux-reactstrap-modal/issues/2
This change should fix the issue with `Cannot read property` error.

The `mapStateToProps` should now return default values if there's no data for a given dialog name.